### PR TITLE
Show testsuite choices in --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ ./run.py [testsuite]
 The list can grow, please refer to:
 
 ```bash
-$ ./run.py list  # for now just shows error with all possible options
+$ ./run.py --help
 ```
 
 ### CLI

--- a/testsuite/run.py
+++ b/testsuite/run.py
@@ -43,7 +43,8 @@ def argument_parser(testsuites):
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('testsuite', nargs='+',
-                        choices=testsuites)
+                        choices=testsuites, metavar='testsuite',
+                        help='{%(choices)s}')
     parser.add_argument('--size', '-s', type=pixel_size, default=[2560, 1600])
     parser.add_argument('--mode', '-m', default="RGB",
                         choices=["RGB", "RGBA", "RGBa", "L", "LA", "La"],)

--- a/testsuite/run.py
+++ b/testsuite/run.py
@@ -43,7 +43,7 @@ def argument_parser(testsuites):
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('testsuite', nargs='+',
-                        choices=testsuites, metavar='testsuite')
+                        choices=testsuites)
     parser.add_argument('--size', '-s', type=pixel_size, default=[2560, 1600])
     parser.add_argument('--mode', '-m', default="RGB",
                         choices=["RGB", "RGBA", "RGBa", "L", "LA", "La"],)


### PR DESCRIPTION
So we can do `./run.py --help` to see the test suites available, rather than `./run.py list` which shows an error.

Before:
```bash
$ python run.py --help
usage: run.py [-h] [--size SIZE] [--mode {RGB,RGBA,RGBa,L,LA,La}]
              [--runs RUNS] [--sleep] [--progress] [--json]
              testsuite [testsuite ...]

positional arguments:
  testsuite

optional arguments:
  -h, --help            show this help message and exit
  --size SIZE, -s SIZE
  --mode {RGB,RGBA,RGBa,L,LA,La}, -m {RGB,RGBA,RGBa,L,LA,La}
  --runs RUNS, -n RUNS
  --sleep
  --progress, -p
  --json, -j
```

After first commit:
```
$ python run.py --help
usage: run.py [-h] [--size SIZE] [--mode {RGB,RGBA,RGBa,L,LA,La}]
              [--runs RUNS] [--sleep] [--progress] [--json]
              {convert,scale,wand_scale,blur,wand_resize,composition,resize}
              [{convert,scale,wand_scale,blur,wand_resize,composition,resize} ...]

positional arguments:
  {convert,scale,wand_scale,blur,wand_resize,composition,resize}

optional arguments:
  -h, --help            show this help message and exit
  --size SIZE, -s SIZE
  --mode {RGB,RGBA,RGBa,L,LA,La}, -m {RGB,RGBA,RGBa,L,LA,La}
  --runs RUNS, -n RUNS
  --sleep
  --progress, -p
  --json, -j
```

After second commit, better:
```bash
$ python run.py --help
usage: run.py [-h] [--size SIZE] [--mode {RGB,RGBA,RGBa,L,LA,La}]
              [--runs RUNS] [--sleep] [--progress] [--json]
              testsuite [testsuite ...]

positional arguments:
  testsuite             {convert, scale, wand_scale, blur, wand_resize,
                        composition, resize}

optional arguments:
  -h, --help            show this help message and exit
  --size SIZE, -s SIZE
  --mode {RGB,RGBA,RGBa,L,LA,La}, -m {RGB,RGBA,RGBa,L,LA,La}
  --runs RUNS, -n RUNS
  --sleep
  --progress, -p
  --json, -j
```
