### PR TITLE
Use square kernel for cv2_filter case

### DIFF
--- a/testsuite/cases/cv2_filter.py
+++ b/testsuite/cases/cv2_filter.py
@@ -11,7 +11,8 @@ from .cv2 import Cv2TestCase, cv2
 class FilterCase(Cv2TestCase):
     def handle_args(self, name, kernel):
         self.name = name
-        kernel = numpy.asarray(kernel, numpy.float32)
+        size = int(len(kernel) ** 0.5)
+        kernel = numpy.asarray(kernel, numpy.float32).reshape((size, size))
         self.kernel = kernel / kernel.sum()
 
     def runner(self, im):


### PR DESCRIPTION
There was an error with kernel size: it was 9x1 and 25x1 rather than 3x3 and 5x5. This doesn't affect results much though.