### PR TITLE
update libvips url

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -147,9 +147,9 @@
                 libvips is a demand-driven, horizontally threaded
                 image processing library. Compared to similar libraries,
                 libvips runs quickly and uses little memory.
-                In this benchmarks <a href="https://jcupitt.github.io/pyvips/">
+                In this benchmarks <a href="https://libvips.github.io/pyvips/">
                     pyvips wrapper</a> is used.
-                <a href="https://jcupitt.github.io/libvips/">homepage</a>
+                <a href="https://libvips.github.io/libvips/">homepage</a>
             </dd>            
             
 


### PR DESCRIPTION
libvips has a new home in the libvips organisation. This PR updates the URL in the docs.