### PR TITLE
Moved Trusty jobs to Xenial, updating PyPy to 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,8 @@ after_success:
 matrix:
   fast_finish: true
   include:
-    - python: pypy
-      dist: trusty
-    - python: pypy3
-      dist: trusty
+    - python: pypy2.7-6.0
+    - python: pypy3.5-6.0
     - python: 3.7
     - python: 2.7
     - python: nightly


### PR DESCRIPTION
As in https://github.com/python-pillow/Pillow/pull/3765, Trusty is EOL this month https://linuxlifecycle.com/