### PR TITLE
Update Travis CI badge for .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Test Suites
 
-[![Build Status](https://api.travis-ci.org/python-pillow/pillow-perf.svg?branch=master)](https://travis-ci.org/python-pillow/pillow-perf)
+[![Build Status](https://travis-ci.com/python-pillow/pillow-perf.svg?branch=master)](https://travis-ci.com/github/python-pillow/pillow-perf)
 
 Performance tests divided into suites.
 


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/5020.

Travis CI has migrated from https://travis-ci.org to https://travis-ci.com

