### PR TITLE
Updated to Ubuntu 18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
             # https://github.com/pypa/wheel/issues/354
             # "3.10-dev",
         ]
-        os: [ubuntu-16.04]
+        os: [ubuntu-18.04]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
With #106 and #117, the GitHub Actions aren't running.

I find that if I upgrade to Bionic, they work.