### PR TITLE
Updated checkout and setup-python actions to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,18 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-            "pypy3",
+            "pypy-3.7",
+            "pypy-3.8",
             "3.9",
             "3.10",
         ]
         os: [ubuntu-18.04]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
actions/setup-python have now released v3 - https://github.com/actions/setup-python/releases/tag/v3.0.0
And so has actions/checkout - https://github.com/actions/checkout/releases/tag/v3.0.0

In the setup-python release notes, they have removed the "pypy3" keyword, so I've replaced it here with pypy-3.7 and pypy-3.8.