### PR TITLE
Updated GitHub Actions to ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             "3.9",
             "3.10",
         ]
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-            "pypy-3.7",
-            "pypy-3.8",
-            "3.9",
+            "pypy-3.9",
+            "pypy-3.10",
             "3.10",
+            "3.11",
         ]
         os: [ubuntu-latest]
 

--- a/testsuite/cases/pillow.py
+++ b/testsuite/cases/pillow.py
@@ -5,7 +5,8 @@ from PIL import Image, ImageFilter, ImageOps
 from .base import BaseTestCase, root
 
 
-Image.LANCZOS = Image.ANTIALIAS
+if hasattr(Image, "ANTIALIAS"):
+    Image.LANCZOS = Image.ANTIALIAS
 
 
 class PillowTestCase(BaseTestCase):


### PR DESCRIPTION
- The [latest run](https://github.com/python-pillow/pillow-perf/actions/runs/5814645653) of #125 failed because it could find runners for the jobs - Ubuntu 18 is no longer supported. This PR updates to test on ubuntu-latest instead
- Pillow 10.0.0 has dropped support for [Python 3.7](https://pillow.readthedocs.io/en/stable/installation.html#python-support), so this PR also updates Python versions in GitHub Actions
- The test suite uses `Image.ANTIALIAS`, which was [removed in Pillow 10.0.0](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants), so this removes that code.